### PR TITLE
return links to random images with unvalidated annotations

### DIFF
--- a/demo/task_wsl.py
+++ b/demo/task_wsl.py
@@ -1,0 +1,13 @@
+import subprocess
+import os
+from vaapi.client import Vaapi
+
+client = Vaapi(
+        base_url=os.environ.get("VAT_API_URL"),
+        api_key=os.environ.get("VAT_API_TOKEN"),
+    )
+mylist= client.annotations.task(class_name="ball", amount=10)["result"]
+
+print(mylist)
+for link in mylist:
+    subprocess.run(['powershell.exe', '-Command', f'Start-Process "{link}"'])

--- a/django/annotation/urls.py
+++ b/django/annotation/urls.py
@@ -6,7 +6,7 @@ app_name = "annotation"
 
 urlpatterns = [
     path("annotation-count/", views.AnnotationCount.as_view(), name="annotation-count"),
-    path("annotation-unvalidated/",views.AnnotationsUnvalidated.as_view(),name="unvalidated_annotations")
+    path("annotation-task/",views.AnnotationTask.as_view(),name="annotation-task")
 ]
 
 router = routers.DefaultRouter()

--- a/django/annotation/urls.py
+++ b/django/annotation/urls.py
@@ -6,6 +6,7 @@ app_name = "annotation"
 
 urlpatterns = [
     path("annotation-count/", views.AnnotationCount.as_view(), name="annotation-count"),
+    path("annotation-unvalidated/",views.AnnotationsUnvalidated.as_view(),name="unvalidated_annotations")
 ]
 
 router = routers.DefaultRouter()

--- a/django/annotation/views.py
+++ b/django/annotation/views.py
@@ -25,6 +25,8 @@ class AnnotationTask(APIView):
         else:
             amount = 50
 
+        # FIXME allow for other filters like class name here
+
         links = []
 
         if len(queryset) < amount:

--- a/django/annotation/views.py
+++ b/django/annotation/views.py
@@ -9,7 +9,7 @@ from .models import Annotation
 from .serializers import AnnotationSerializer
 
 
-class AnnotationsUnvalidated(APIView):
+class AnnotationTask(APIView):
     def get(self,request):
 
         query_params = request.query_params.copy()

--- a/django/annotation/views.py
+++ b/django/annotation/views.py
@@ -3,11 +3,51 @@ from rest_framework import viewsets
 from rest_framework import status
 from rest_framework.response import Response
 from django.db.models import Q, F
-
+import random
+from django.conf import settings
 from .models import Annotation
 from .serializers import AnnotationSerializer
 
 
+class AnnotationsUnvalidated(APIView):
+    def get(self,request):
+
+        query_params = request.query_params.copy()
+
+        queryset = Annotation.objects.filter(validated=False)
+
+        if "log" in query_params.keys():
+            log_id = int(query_params.pop("log")[0])
+            queryset = queryset.filter(image__frame__log=log_id)
+
+        if "amount" in query_params.keys():
+            amount = int(query_params.pop("amount")[0])
+        else:
+            amount = 50
+
+        links = []
+
+        if len(queryset) < amount:
+            amount= len(queryset)
+
+        queryset = list(queryset)
+        for i in range(amount):
+
+            annotation = random.choice(queryset)
+            queryset.remove(annotation)
+            if settings.DEBUG:
+                # Development - use localhost
+                domain = "127.0.0.1:8000"
+                scheme = "http"
+            else:
+                # Production - use your actual domain
+                domain = "vat.berlin-united.com"  
+                scheme = "https"
+            links.append(f"{scheme}://{domain}/log/{annotation.image.frame.log.id}/frame/{annotation.image.frame.frame_number}?filter=None")
+
+        return Response({"result": links}, status=status.HTTP_200_OK)
+        
+        
 class AnnotationCount(APIView):
     def get(self, request):
         # Get filter parameters from query string

--- a/sdk/vaapi/__init__.py
+++ b/sdk/vaapi/__init__.py
@@ -1,7 +1,7 @@
 """This package provides a client class that serves as wrapper for operations that
 you can perform with the API of the visual analytics tool by Berlin United for the Robocup SPL"""
 
-__version__ = "0.6.17"
+__version__ = "0.6.18"
 
 __pdoc__ = {
     "core": False,  # Excludes the entire module/folder

--- a/sdk/vaapi/annotations/client.py
+++ b/sdk/vaapi/annotations/client.py
@@ -204,3 +204,35 @@ class AnnotationsClient:
         except JSONDecodeError:
             raise ApiError(status_code=_response.status_code, body=_response.text)
         raise ApiError(status_code=_response.status_code, body=_response_json)
+    
+    def task(
+        self,
+        request_options: typing.Optional[RequestOptions] = None,
+        **filters: typing.Any,
+    ) -> typing.Optional[int]:
+        """
+        Examples
+        --------
+        from vaapi.client import Vaapi
+
+        client = Vaapi(
+            base_url='https://vat.berlin-united.com/',
+            api_key="YOUR_API_KEY",
+        )
+        """
+        query_params = {k: v for k, v in filters.items() if v is not None}
+        _response = self._client_wrapper.httpx_client.request(
+            "api/annotation-task/",
+            method="GET",
+            request_options=request_options,
+            params=query_params,
+        )
+        try:
+            if 200 <= _response.status_code < 300:
+                return pydantic_v1.parse_obj_as(
+                    typing.Dict[str, typing.Any], _response.json()
+                )  # type: ignore
+            _response_json = _response.json()
+        except JSONDecodeError:
+            raise ApiError(status_code=_response.status_code, body=_response.text)
+        raise ApiError(status_code=_response.status_code, body=_response_json)


### PR DESCRIPTION
added new endpoint that returns links of  random images that contain unvalidated annotations.

query params:
log - allows filtering for a specific log
amount - specifies the amount of links