### PR TITLE
fix old tests and updated TeamFactory

### DIFF
--- a/django/tests/common/factories.py
+++ b/django/tests/common/factories.py
@@ -21,29 +21,21 @@ class EventFactory(DjangoModelFactory):
     comment = factory.Faker("text")
 
 
-class Team1Factory(DjangoModelFactory):
+class TeamFactory(DjangoModelFactory):
     class Meta:
         model = Team
+        # this should ensure that factory treats team_id as unique value
+        django_get_or_create = ('team_id',)
 
-    team_id = 3
-    name = "Random Team 1"
-
-
-class Team2Factory(DjangoModelFactory):
-    class Meta:
-        model = Team
-
-    team_id = 4
-    name = "Random Team 2"
-
-
+    team_id = factory.Sequence(lambda n: n + 1)
+    name = factory.LazyAttribute(lambda obj: f"Team Name {obj.team_id}")
 class GameFactory(DjangoModelFactory):
     class Meta:
         model = Game
 
     event = factory.SubFactory(EventFactory)
-    team1 = factory.SubFactory(Team1Factory)  # FIXME this will lead to unique violations
-    team2 = factory.SubFactory(Team2Factory)  # FIXME this will lead to unique violations
+    team1 = factory.SubFactory(TeamFactory)
+    team2 = factory.SubFactory(TeamFactory)
     half = fuzzy.FuzzyChoice(["half1", "half2"])
     is_testgame = factory.Faker("boolean")
     head_ref = factory.Faker("name")

--- a/django/tests/common/test_models.py
+++ b/django/tests/common/test_models.py
@@ -7,6 +7,7 @@ from .factories import (
     VideoRecordingFactory,
     LogFactory,
     LogStatusFactory,
+    TeamFactory
 )
 
 pytestmark = pytest.mark.unit
@@ -25,13 +26,15 @@ class TestCommonModels:
     def test_game(self):
         GameFactory.create(
             half="half1",
+            team1 = TeamFactory(name="Team A"),
+            team2 = TeamFactory(name="Team B"),
             start_time="2024-01-01 12:00:00+00:00",
         )
         assert Game.objects.count() == 1
         db_game = Game.objects.first()
         assert str(db_game) == "2024-01-01 12:00:00+00:00: Team A vs Team B half1"
-        assert db_game.team1 == "Team A"
-        assert db_game.team2 == "Team B"
+        assert db_game.team1.name == "Team A"
+        assert db_game.team2.name == "Team B"
         assert db_game.half == "half1"
         assert db_game.event is not None
 
@@ -101,8 +104,8 @@ class TestCommonModels:
     @pytest.mark.django_db
     def test_log_properties(self):
         game = GameFactory.create(
-            team1="Team A",
-            team2="Team B",
+            team1=TeamFactory(name="Team A"),
+            team2=TeamFactory(name="Team B"),
             half="half1",
         )
         log = LogFactory.create(game=game)

--- a/django/tests/common/test_serializer.py
+++ b/django/tests/common/test_serializer.py
@@ -43,8 +43,8 @@ class TestSerializers:
         serializer = GameSerializer(game)
         data = serializer.data
 
-        assert data["team1"] == game.team1
-        assert data["team2"] == game.team2
+        assert data["team1"] == game.team1.name
+        assert data["team2"] == game.team2.name
         assert data["half"] == game.half
         assert data["event"] == game.event.id
 


### PR DESCRIPTION
updated TeamFactory to have a unique name and id each time an team object is created.

fixed old tests by using TeamFactory(name=string) instead of assigning game.team1 and game.team2 string values 